### PR TITLE
Make tox the main test runner

### DIFF
--- a/.github/workflows/drawdown.yml
+++ b/.github/workflows/drawdown.yml
@@ -20,7 +20,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Test with tox
       run: |
-        pip install tox==3.14.0
+        pip install tox
         tox -e ci
     - name: Export to codecov.io
       uses: codecov/codecov-action@v1.0.2

--- a/.github/workflows/drawdown.yml
+++ b/.github/workflows/drawdown.yml
@@ -18,11 +18,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Test with pytest
+    - name: Test with tox
       run: |
-        pip install pytest
-        pytest -v --cov=. --cov-report term --cov-report=xml --strict-markers
+        pip install tox==3.14.0
+        tox -e ci
     - name: Export to codecov.io
       uses: codecov/codecov-action@v1.0.2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 .ipynb_checkpoints
 
 .tox
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 default: test
 
 test:
-	pytest -v -m "not slow" --strict-markers -W ignore::DeprecationWarning
+	tox
 
 alltest:
-	pytest -v --cov=. --cov-report term-missing --strict-markers -W ignore::DeprecationWarning
+	tox -e all
 
 alltests: alltest
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    slow: mark a test as taking a long time.

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,28 @@
 [tox]
-envlist=py38
-skipsdist=True
+envlist = py38
+skipsdist = True
 
 [testenv]
 # one virtual env for all test - without this line tox will install .tox/all env to run the 'all' suit
-envdir = {toxinidir}/.tox
+envdir = {toxworkdir}/common
 
 deps =
     -rrequirements.txt
 
 commands =
-    pytest -v -m "not slow" --strict-markers -W ignore::DeprecationWarning {posargs}
-
-[testenv:verbose]
-commands =
-    pytest -sxv {posargs}
+    pytest -m "not slow" {posargs}
 
 [testenv:all]
 commands =
-    pytest -v --strict-markers -W ignore::DeprecationWarning --cov=. --cov-report term-missing {posargs}
+    pytest --cov=. --cov-report term-missing {posargs}
+
+# runs on github workflow
+[testenv:ci]
+commands =
+    pytest --cov=. --cov-report term --cov-report=xml
+
+[pytest]
+addopts = -v -W once::DeprecationWarning --strict-markers
+ignore = .tox .git data
+markers =
+    slow: mark a test as taking a long time.

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
     pytest --cov=. --cov-report term --cov-report=xml
 
 [pytest]
-addopts = -v -W once::DeprecationWarning --strict-markers
-ignore = .tox .git data
+addopts = -v -W ignore::DeprecationWarning --strict-markers
+ignore = .tox .git
 markers =
     slow: mark a test as taking a long time.


### PR DESCRIPTION
Fix #11 
continuing #38 

### What this PR does

 * Fix tox issue by changing `envdir` to something more sensible
 * Make `tox` the single point test runner - it's called from Makefile and github workflow
 * Remove `pytest.ini` and move its content to `tox.ini`
 * Use `once::DeprecationWarning` instead of `ignore::DeprecationWarning`
