### PR TITLE
Try to run workflow on pull request.

### DIFF
--- a/.github/workflows/drawdown.yml
+++ b/.github/workflows/drawdown.yml
@@ -1,6 +1,6 @@
 name: Drawdown Solutions Python application
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -27,3 +27,6 @@ jobs:
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.xml
+      env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+      if: env.CODECOV_TOKEN != ''


### PR DESCRIPTION
Codecov has to be skipped because the secret isn't available.

codecov.io understands that this is an issue which needs a better
resolution: https://github.com/codecov/codecov-action/issues/44