### PR TITLE
Run workflow on pull request.

### DIFF
--- a/.github/workflows/drawdown.yml
+++ b/.github/workflows/drawdown.yml
@@ -1,6 +1,12 @@
 name: Drawdown Solutions Python application
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:
@@ -27,3 +33,6 @@ jobs:
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.xml
+      env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+      if: env.CODECOV_TOKEN != ''


### PR DESCRIPTION
Codecov has to be skipped because the secret isn't available in pull
requests from forks, but we want to run the rest of the workflow.
This means that coverage will not be updated until the next pull_request
from the main repository... which is not ideal, as we may not realize it
was the earlier pull_request which impacted coverage.

codecov.io understands that this is an issue which needs a better
resolution: https://github.com/codecov/codecov-action/issues/44