### PR TITLE
Add GITHUB_TOKEN to survey-health.yml

### DIFF
--- a/.github/workflows/survey-health.yml
+++ b/.github/workflows/survey-health.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         lfs: true
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up Python
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
As described in https://github.com/stefanzweifel/git-auto-commit-action/issues/2#issuecomment-599721261

and referencing:
https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token