### PR TITLE
Switch survey-health workflow to create a PR.

### DIFF
--- a/.github/workflows/survey-health.yml
+++ b/.github/workflows/survey-health.yml
@@ -24,19 +24,11 @@ jobs:
       run: |
         pip install tox
         tox -e health_update
-    - uses: stefanzweifel/git-auto-commit-action@v4.1.1
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v2.4.4
       with:
-        commit_message: Updating survey health files    
-        # Optional name of the branch the commit should be pushed to
-        # Required if Action is used in Workflow listening to the `pull_request` event
-        branch: ${{ github.head_ref }}
-    
-        # Optional glob pattern of files which should be added to the commit
-        file_pattern: data/health/*
-    
-        # Optional local file path to the repository
-        repository: .
-    
-        # Optional commit user and author settings
-        commit_user_name: Survey Health Cron Job
-        commit_user_email: drawdownbot@decarbon.earth
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit_message: Updating survey health files
+        title: Updating survey health files
+        author: Survey Health Cron Job <drawdownbot@decarbon.earth>
+        team-reviewers: owners, maintainers


### PR DESCRIPTION
The master branch is protected in this repository, and the GITHUB_TOKEN
does not have the rights to push to it. Though we could create a
Personal Access Token for someone who does have that permission, the
failure mode if the bot does something bad is harder to recover from if
people cloned master in the time it was broken. We'd like to preserve
the chance for review before merging.

Switch from stefanzweifel/git-auto-commit-action@v4.1.1 to
peter-evans/create-pull-request@v2.4.4 to create a pull request
instead.