### PR TITLE
survey health: push to a different branch

### DIFF
--- a/.github/workflows/survey-health.yml
+++ b/.github/workflows/survey-health.yml
@@ -24,11 +24,20 @@ jobs:
       run: |
         pip install tox
         tox -e health_update
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v2.4.4
+    - name: Create Survey Update Commit
+      uses: stefanzweifel/git-auto-commit-action@v4.1.1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
         commit_message: Updating survey health files
-        title: Updating survey health files
-        author: Survey Health Cron Job <drawdownbot@decarbon.earth>
-        team-reviewers: owners, maintainers
+        # Optional name of the branch the commit should be pushed to
+        # Required if Action is used in Workflow listening to the `pull_request` event
+        branch: ${{ github.solution-survey-cron }}
+
+        # Optional glob pattern of files which should be added to the commit
+        file_pattern: data/health/*
+
+        # Optional local file path to the repository
+        repository: .
+
+        # Optional commit user and author settings
+        commit_user_name: Survey Health Cron Job
+        commit_user_email: drawdownbot@decarbon.earth


### PR DESCRIPTION
We tried having the Workflow create a Pull Request, but (by
github's design) an Action doesn't trigger other Actions so
the PR does not run the continuous integration tests.

Instead, push to a specially named branch and expect one of the
maintainers to manually create a Pull Request. We'll see if this
works well enough.