### PR TITLE
zenodo.json: make license inner field "id"

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -40,7 +40,7 @@
   "description": "The mission of Project Drawdown is to help the world reach 'Drawdown'— the point in the future when levels of greenhouse gases in the atmosphere stop climbing and start to steadily decline, thereby stopping catastrophic climate change — as quickly, safely, and equitably as possible.",
   "access_right": "open",
   "license": 
-    {
-      "type": "AGPL-3.0"
-    }
+  {
+    "id": "AGPL-3.0"
+  }
 }


### PR DESCRIPTION
https://zenodo.org/record/3467890/export/json#.XtV6xZ5KgWo suggests it
should be "id" instead of "type"