### PR TITLE
excel_fair_results: add 2017 book support

### DIFF
--- a/tools/tests/test_excel_fair_results.py
+++ b/tools/tests/test_excel_fair_results.py
@@ -19,7 +19,7 @@ def test_animation_file(tmpdir):
     # We use GIF and PIL here to not require CI/CD servers to install ffmpeg for mp4.
     writer = matplotlib.animation.PillowWriter()
     filename = this_dir.joinpath('excel_fair_results_test.xlsx')
-    efr.process_ghgs(excelfile=filename, outdir=str(tmpdir), writer=writer, ext='.gif')
+    efr.process_ghgs(file2020=filename, outdir=str(tmpdir), writer=writer, ext='.gif')
     for pds in range(1, 3):
         outfile = tmpdir.join(f"excel_fair_results_test_PDS{pds}.gif")
         assert outfile.size() > 1024


### PR DESCRIPTION
tools/excel_fair_results.py was developed to pull emissions data from
the spreadsheet used to integrate all of the solutions for the 3/2020
publication of [The Drawdown Review]
(https://www.drawdown.org/drawdown-framework/drawdown-review-2020)
and run the emissions data through
[FaIR](https://github.com/OMS-NetZero/FAIR)
to get temperature and atmospheric concentration results.

This change adds the same FaIR processing for the results from the
2017 [Project Drawdown Book](https://drawdown.org/the-book).