### PR TITLE
tox: remove pipenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,52 +5,39 @@ skipsdist = True
 [testenv]
 # one virtual env for all test - without this line tox will install .tox/all env to run the 'all' suit
 envdir = {toxworkdir}/common
-setenv =
-    PYTHONPATH = {toxinidir}
-    PIPENV_IGNORE_PIPFILE=1
-    PIPENV_NO_INHERIT=1
-    PIPENV_HIDE_EMOJIS=1
+setenv = PYTHONPATH = {toxinidir}
 
 deps =
-    pipenv
-
-create =
-    pipenv install --dev --ignore-pipfile
+    -rrequirements.txt
 
 commands =
-    {[testenv]create}
-    pipenv run pytest -m "not slow" {posargs}
+    python -m pytest -m "not slow" {posargs}
 
 [testenv:all]
 commands =
-    {[testenv]create}
-    pipenv run pytest --cov=. --cov-report term-missing {posargs}
+    python -m pytest --cov=. --cov-report term-missing {posargs}
 
 # runs on github workflow
 [testenv:ci]
 commands =
-    {[testenv]create}
-    pipenv run pytest --cov=. --cov-report term --cov-report=xml
+    python -m pytest --cov=. --cov-report term --cov-report=xml
 
 [testenv:web_ui]
 commands =
-    {[testenv]create}
-    pipenv run pytest tests/test_web_ui.py
+    python -m pytest tests/test_web_ui.py
 
 [testenv:health_update]
 commands =
-    {[testenv]create}
-    pipenv run python tools/health/survey.py
-    pipenv run python tools/health/landsurvey.py
-    pipenv run python dashboard/__main__.py
+    python tools/health/survey.py
+    python tools/health/landsurvey.py
+    python dashboard/__main__.py
 
 [testenv:lint]
 deps =
     {[testenv]deps}
     pylint
 commands =
-    {[testenv]create}
-    pipenv run pylint --rcfile=tox.ini dashboard data model solution tests tools ui
+    python -m pylint --rcfile=tox.ini data model solution tests tools ui dashboard
 
 # ==== pylint section
 [MASTER]
@@ -72,12 +59,3 @@ filterwarnings =
     ignore::DeprecationWarning:ipywidgets.*:
 markers =
     slow: mark a test as taking a long time.
-
-[testenv:update-requirements]
-deps =
-    pipenv
-commands =
-    pipenv lock --clear
-    bash -c "pipenv lock -r > {toxinidir}/requirements.txt"
-whitelist_externals =
-    bash


### PR DESCRIPTION
Increases time to run the CI tests from ~2 hours to ~5 hours.