### PR TITLE
Add pipenv, tox, and jupyter port config to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY . /app/
 WORKDIR /app
 
 RUN python -m pip install --upgrade pip
+RUN pip install pipenv
+RUN pip install tox
 RUN pip install -r requirements.txt
 
 EXPOSE 8000

--- a/docker-compose.yml.local.example
+++ b/docker-compose.yml.local.example
@@ -19,6 +19,7 @@ services:
       context: .
     ports:
       - "8000:8000"
+      - "8866:8866"
     volumes:
       - .:/app
     environment:


### PR DESCRIPTION
Working on running the following steps from the master branch readme. To reproduce set up docker (`cp docker-compose.local.yml docker-compose.yml`, `docker-compose up`) then `docker-compose run web bash -l` and try running `tox -- tools/tests/test_vma_xls_extract.py::test_read_xls` both within and outside of a pipenv virtual environment.

```
$ WORKON_HOME="${PWD}/.tox/common" pipenv shell
(solutions) $ pipenv install -r requirements.txt
(solutions) $ jupyter nbextension install --py --sys-prefix vega
(solutions) $ jupyter nbextension enable vega --py --sys-prefix
(solutions) $ voila --enable_nbextensions=True --VoilaConfiguration.file_whitelist="['.*\.(png|jpg|gif|svg|csv|json|ico|js)']" ./VoilaDrawdown.ipynb
```