### PR TITLE
revamp CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,62 @@
 # Contributing to Project Drawdown Solutions
 
 Welcome to the Project Drawdown Solutions repository! We're excited that you're here and want to help
-with solutions to climate change.   These guidelines are designed to make it as easy as possible 
+with solutions to climate change.   These guidelines are intended to make it as easy as possible 
 to get involved. If you have any questions that aren't discussed below, please let us know by 
 [opening an issue](https://github.com/ProjectDrawdown/solutions/issues)!
 
-We appreciate all contributions to Project Drawdown Solutions, but those most easily accepted will follow a workflow
-similar to the following:
+If you are new to git and/or the github process for contributions,
+[Collaborating with Pull Requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
+is a great reference for the model that we follow.
+We appreciate all contributions to Project Drawdown Solutions, but following those guidelines should make the
+process easier for everyone.
 
-1. **Check out the [Issues List](https://github.com/ProjectDrawdown/solutions/issues)**
+## Finding Items in the Issues List
 
-    There you will see work in progress (issues that have an assigned individual), and issues that we haven't begun to work on yet.
-    Whether you find one that interests you, or have an idea that you'd like to work on that you don't see there, proceed to:
+The [Issues List](https://github.com/ProjectDrawdown/solutions/issues) is where we keep work items that are not
+started or are currently in progress.   The tags used in the list vary over time, but there are a couple of tags that are
+useful to know when you are getting started:
 
-1. **Comment on an existing issue or open a new issue for a new idea.**  
+ * `good first issue`  This is an issue that has relatively few dependencies on the overall code, so it can be
+ worked on without having to understand how everything works.
+ * `help wanted`  This label is applied to issues that are currently high priority and/or to issues that have assigned
+ people but still would welcome additional collaborators.
+ * `dependencies`  This is an issue that is currently blocked because of other tasks that need to be completed.  The comments
+ in the issue should indicate what those dependencies are.
 
-    This allows other members of the development team to confirm that you aren't overlapping with work that's currently underway and that everyone is on the same page with the goal of the work you're going to carry out.   
-  
-    Discussing the change first is especially important for substantive changes to be made in the model directory. The Drawdown methodology has been published and undergone substantial peer review. Changes to the model have to be vetted, and ensure that they fit within the reviewed methodology.  
+Note that the `Priority` tags are used for internal project management, but do _not_ necessarily correspond to the actual
+priority of the issue.  An issue might be marked `Priority 3` because the core development team can't get to it right now,
+but we would be super excited if someone else could.
 
-1. **[Fork](https://help.github.com/articles/fork-a-repo/) the Project Drawdown Solutions repository to your profile.**  
+## Current Development Priorities and Plans
 
-    This is now your own unique copy of the codebase. Changes here won't affect anyone else's work, so it's a safe space to explore edits to the code. 
-    It's a good practice to create [a new branch](https://help.github.com/articles/about-branches/) of the repository for a new set of changes.  
-  
-    Make sure to keep your fork up to date with the original repository. One way to do this is to [configure a new remote named "upstream"](https://help.github.com/articles/configuring-a-remote-for-a-fork/) and to [sync your fork with the upstream repository](https://help.github.com/articles/syncing-a-fork/).  
+Our current development priorities and plans are maintained in 
+[the project wiki](https://github.com/ProjectDrawdown/solutions/wiki).
+Look here for updates on what has happened and what is coming up.
 
-1. **Develop and Test.**  
+## Proposing new Work
 
-    Now you can work on the changes you have planned.  We encourage you to reach out for assistance as you work.  One way to do this easily is to create a Work-In-Progress (WIP) pull request (see the next section).
+Have an idea to improve this project?  Great!  Open a new issue for any new enhancement you would like to work on, and
+assign yourself.  It is a good idea to request feedback (via comments on your new issue); this allows other members of the development team to confirm that you aren't overlapping with work that's currently underway and that everyone is on the same page with the goal of the work you're going to carry out.
 
-    While you are working on your changes, test frequently to ensure you are not breaking the existing code. See [TESTING.md](TESTING.md) for guidance.   New code should include tests to cover the new functionality (and _must_ include test
-    coverage for code that generates analytic results)
+Discussing the change first is especially important for changes to be made in the analytic models in the `model` directory. The Drawdown methodology has been published and undergone substantial peer review. Changes to the model have to be vetted to ensure that they fit within the reviewed methodology.
 
-1. **Submit a [pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).**  
+## Please Work in your own Branch, and use Draft Pull Requests for Collaboration
 
-    A new pull request for your changes should be created from your fork of the repository.  
-  
-    Pull requests should be submitted early and often (please don't mix too many unrelated changes within one PR)! If your pull request is not yet ready to be merged, please mark it as a 'draft' pull request and please also include the **[WIP]** prefix (you can remove it once your PR is ready to be merged). This tells the development team that your pull request is a "work-in-progress", and that you plan to continue working on it.  
+It is much easier to manage collaboration if your work is in its own branch.  By making a draft pull request, you can share your current work in progress with the core team and also with other developers who might be interested in helping out.
 
-    Review and discussion on new code can begin well before the work is complete, and the more discussion the better. The development team may prefer a different path than you've outlined, so it's better to discuss it and get approval at the early stage of your work.  
+## Excel Import and NDAs
 
-    Once your PR is ready a member of the development team will review your changes to confirm that they can be merged into the main codebase.
+Issues marked `Excel Import` are tasks to translate existing Excel code into python.  Some of the information in the Excel workbooks
+is confidential, so we need to ask contributors to sign an NDA in order to give them access to those workbooks.  If you are 
+interested in participating in this work, please [fill out this form](https://forms.gle/GWhqwN3rs78knNAt8) to get started.
 
 ## Review Process
 
 In addition to the normal code review which any pull request will undergo, changes which augment or modify the analytical functionality of the models will need to be approved by Project Drawdown research team before being accepted into the repository.   Advance discussion with the development team will help us set up
 the research review in a timely manner.
 
-## See Also
 
-There is a special guide for converting Excel models to python:  you can find that [here](link coming soon).
 
-## Recognizing contributions
-
-We welcome and recognize all contributions from documentation to testing to code development.
-
-You can see a list of current contributors in our [zenodo file][https://github.com/ProjectDrawdown/solutions/blob/develop/.zenodo.json], which we use to
-generate author lists [as described in this blog post](http://blog.chrisgorgolewski.org/2017/11/sharing-academic-credit-in-open-source.html).
-If you are new to the project, don't forget to add your name and affiliation there as part of your pull request!
 
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ The python code for the model engine is licensed under the GNU Affero General Pu
 
 Data supplied from Project Drawdown (mostly in the form of CSV files) is licensed under the [CC-BY-NC-2.0](https://creativecommons.org/licenses/by-nc/2.0/) license for non-commercial use. The code for the model can be used (under the terms of the AGPL) to process whatever data the user wishes under whatever license the data carries. The data supplied for the Project Drawdown solutions is CC-BY-NC-2.0.
 
+## Support
+Please use the [Issues List](https://github.com/ProjectDrawdown/solutions/issues) to report any bugs you find, or ask any
+questions you have.
+
+
 ## Contributing
 We would love to have your help.
 Please see [CONTRIBUTING.md](Contributing.md) for guidelines for contributing to this project.


### PR DESCRIPTION
In thinking about how to follow up with hackathon participants, I realized I need some different collaboration tools.  Something in between Slack (which is great for conversations with existing collaborators, but doesn't address the public) and a doc in the Repo itself (which is awkward for maintaining something that is supposed to be updated frequently).

This version of CONTRIBUTING.md proposes using the github wiki for public-facing project progress and planning --- I'm imagining something that is oriented towards outside participants who want to keep up to date with what is going on, or new people trying to get some context.  Something that will be updated on the order of monthly, not with every change.   (I'd take point on setting this up, but of course others are welcome to help ;-)

Meanwhile I also wanted to revamp the content away from a general "how to" (which is available elsewhere) and focus more on aspects that are unique to this repo.  One of which is incorporating the need for an NDA for some tasks, and providing a way to point people towards that.