### PR TITLE
key results refactoring

### DIFF
--- a/Key_Results.ipynb
+++ b/Key_Results.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 1,
    "id": "70785e50",
    "metadata": {},
    "outputs": [],
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "id": "aa3bb6da",
    "metadata": {},
    "outputs": [
@@ -61,13 +61,13 @@
        " 'cumulative_emissions_reduced': 2.3034768858097836}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pds1.key_results()"
+    "pds1.get_key_results()"
    ]
   },
   {
@@ -75,7 +75,7 @@
    "id": "2ab0cff3",
    "metadata": {},
    "source": [
-    "`key_results()` returns a dictionary. Of all six key results. We can also access each result individually."
+    "`get_key_results()` returns a dictionary. Of all six key results. We can also access each result individually."
    ]
   },
   {
@@ -140,7 +140,7 @@
     }
    ],
    "source": [
-    "pds1.key_results(year=2050)"
+    "pds1.get_key_results(year=2050)"
    ]
   },
   {
@@ -174,7 +174,7 @@
     }
    ],
    "source": [
-    "pds1.key_results(year=2040)"
+    "pds1.get_key_results(year=2040)"
    ]
   },
   {
@@ -474,7 +474,7 @@
     }
    ],
    "source": [
-    "ocean_solution.key_results()"
+    "ocean_solution.get_key_results()"
    ]
   },
   {

--- a/model/scenario.py
+++ b/model/scenario.py
@@ -142,28 +142,6 @@ class Scenario:
     
     # Common top-level functionality
     # Key Results
-
-    def get_key_results(self, year=2050, region='World'):
-        if (self.solution_category == self.solution_category.REDUCTION or 
-            self.solution_category == self.solution_category.REPLACEMENT or
-            isinstance(self, RRSScenario)):
-            return {'implementation_unit_adoption_increase': self.implementation_unit_adoption_increase(year=year),
-                    'functional_unit_adoption_increase': self.functional_unit_adoption_increase(year=year),
-                    'marginal_first_cost': self.marginal_first_cost(year=year),
-                    'net_operating_savings': self.net_operating_savings(year=year),
-                    'lifetime_operating_savings': self.lifetime_operating_savings(),
-                    'cumulative_emissions_reduced': self.cumulative_emissions_reduced(year=year, region=region)}
-        elif (self.solution_category == self.solution_category.LAND or
-              isinstance(self,LandScenario)):
-            return {'adoption_unit_increase': self.adoption_unit_increase_LAND(year=year),
-                    'marginal_first_cost': self.marginal_first_cost(year=year),
-                    'net_operating_savings': self.net_operating_savings(year=year),
-                    'lifetime_operating_savings': self.lifetime_operating_savings(),
-                    'cumulative_emissions_reduced': self.cumulative_emissions_reduced(year=year, region=region),
-                    'total_additional_co2eq_sequestered': self.total_additional_co2eq_sequestered(year)}
-        else:
-            raise NotImplementedError("key_results only implemented for REDUCTION, REPLACEMENT, LAND and OCEAN.")
-
     def marginal_first_cost(self, year=2050):
         return (self.fc.soln_pds_annual_world_first_cost().loc[:year].sum()-
             self.fc.soln_ref_annual_world_first_cost().loc[:year].sum()-
@@ -259,32 +237,12 @@ class RRSScenario(Scenario):
                 'cumulative_emissions_reduced': self.cumulative_emissions_reduced(year=year, region=region)}
 
     def implementation_unit_adoption_increase(self, year=2050, region='World'):
-        if self.pds_ca and self.pds_ca.soln_adoption_custom_name:
-            pds_adoption = self.pds_ca.adoption_data_per_region()
-        else:
-            pds_adoption = self.ht.soln_pds_funits_adopted()
-
-        if self.ref_ca and self.ref_ca.soln_adoption_custom_name:
-            ref_adoption = self.ref_ca.adoption_data_per_region()
-        else:
-            ref_adoption = self.ht.soln_ref_funits_adopted()
-
-        return (pds_adoption.loc[year][region] / self.ac.soln_avg_annual_use - 
-            ref_adoption.loc[year][region] / self.ac.soln_avg_annual_use)
+        return (self.ht.soln_pds_funits_adopted().loc[year][region] / self.ac.soln_avg_annual_use - 
+            self.ht.soln_ref_funits_adopted().loc[year][region] / self.ac.soln_avg_annual_use)
 
     def functional_unit_adoption_increase(self, year=2050, region='World'):
-        if self.pds_ca and self.pds_ca.soln_adoption_custom_name:
-            pds_adoption = self.pds_ca.adoption_data_per_region()
-        else:
-            pds_adoption = self.ht.soln_pds_funits_adopted()
-
-        if self.ref_ca and self.ref_ca.soln_adoption_custom_name:
-            ref_adoption = self.ref_ca.adoption_data_per_region()
-        else:
-            ref_adoption = self.ht.soln_ref_funits_adopted()
-
-        return (pds_adoption.loc[year] - 
-                ref_adoption.loc[year]
+        return (self.ht.soln_pds_funits_adopted().loc[year] - 
+                self.ht.soln_ref_funits_adopted().loc[year]
                 )[region]
 
 
@@ -306,18 +264,8 @@ class LandScenario(Scenario):
                 'total_additional_co2eq_sequestered': self.total_additional_co2eq_sequestered(year)}
         
     def adoption_unit_increase(self, year=2050, region='World'):
-        if self.pds_ca and self.pds_ca.soln_adoption_custom_name: 
-            pds_adoption = self.pds_ca.adoption_data_per_region()
-        else:
-            pds_adoption = self.ht.soln_pds_funits_adopted()
-
-        if self.ref_ca and self.ref_ca.soln_adoption_custom_name:
-            ref_adoption = self.ref_ca.adoption_data_per_region()
-        else:
-            ref_adoption = self.ht.soln_ref_funits_adopted()
-
-        return (pds_adoption.loc[year][region]  - 
-            ref_adoption.loc[year][region])
+        return (self.ht.soln_pds_funits_adopted().loc[year][region]  - 
+                self.ht.soln_ref_funits_adopted().loc[year][region])
 
     def total_additional_co2eq_sequestered(self, year=2050):
         # farmlandrestoration starts in year 2021 in Advanced Control excel

--- a/model/scenario.py
+++ b/model/scenario.py
@@ -143,7 +143,7 @@ class Scenario:
     # Common top-level functionality
     # Key Results
 
-    def key_results(self, year=2050, region='World'):
+    def get_key_results(self, year=2050, region='World'):
         if self.solution_category == self.solution_category.REDUCTION or self.solution_category == self.solution_category.REPLACEMENT:
             return {'implementation_unit_adoption_increase': self.implementation_unit_adoption_increase(year=year),
                     'functional_unit_adoption_increase': self.functional_unit_adoption_increase(year=year),

--- a/tools/expected_result_tester.py
+++ b/tools/expected_result_tester.py
@@ -1069,19 +1069,17 @@ def key_results_tester(solution_name, expected_filename, scenario_skip=None):
             df_expected = pd.read_csv(ac_file, header=None, na_values=['#REF!', '#DIV/0!', '#VALUE!', '(N/A)'])
             key_results = obj.key_results()
 
-            desired_precision = 7
-            aae = np.testing.assert_almost_equal
             if isinstance(obj, scenario.LandScenario):
-                aae(key_results['adoption_unit_increase'], float(df_expected.loc[3, 0]), decimal=desired_precision)
-                aae(key_results['marginal_first_cost'], float(df_expected.loc[3, 1]), decimal=desired_precision)
-                aae(key_results['net_operating_savings'], float(df_expected.loc[3, 2]), decimal=desired_precision)
-                aae(key_results['lifetime_operating_savings'], float(df_expected.loc[3, 3]), decimal=desired_precision)
-                aae(key_results['cumulative_emissions_reduced'], float(df_expected.loc[3, 4]), decimal=desired_precision)
-                aae(key_results['total_additional_co2eq_sequestered'], float(df_expected.loc[3, 5]), decimal=desired_precision)
+                assert(key_results['adoption_unit_increase'] == pytest.approx(float(df_expected.loc[3, 0])))
+                assert(key_results['marginal_first_cost'] == pytest.approx(float(df_expected.loc[3, 1])))
+                assert(key_results['net_operating_savings'] == pytest.approx(float(df_expected.loc[3, 2])))
+                assert(key_results['lifetime_operating_savings'] == pytest.approx(float(df_expected.loc[3, 3])))
+                assert(key_results['cumulative_emissions_reduced'] == pytest.approx(float(df_expected.loc[3, 4])))
+                assert(key_results['total_additional_co2eq_sequestered'] == pytest.approx(float(df_expected.loc[3, 5])))
             else:
-                aae(key_results['implementation_unit_adoption_increase'], float(df_expected.loc[3, 0]), decimal=desired_precision)
-                aae(key_results['functional_unit_adoption_increase'], float(df_expected.loc[3, 1]), decimal=desired_precision)
-                aae(key_results['marginal_first_cost'], float(df_expected.loc[3, 2]), decimal=desired_precision)
-                aae(key_results['net_operating_savings'], float(df_expected.loc[3, 3]), decimal=desired_precision)
-                aae(key_results['lifetime_operating_savings'], float(df_expected.loc[3, 4]), decimal=desired_precision)
-                aae(key_results['cumulative_emissions_reduced'], float(df_expected.loc[3, 5]), decimal=desired_precision)
+                assert(key_results['implementation_unit_adoption_increase'] == pytest.approx(float(df_expected.loc[3, 0])))
+                assert(key_results['functional_unit_adoption_increase'] == pytest.approx(float(df_expected.loc[3, 1])))
+                assert(key_results['marginal_first_cost'] == pytest.approx(float(df_expected.loc[3, 2])))
+                assert(key_results['net_operating_savings'] == pytest.approx(float(df_expected.loc[3, 3])))
+                assert(key_results['lifetime_operating_savings'] == pytest.approx(float(df_expected.loc[3, 4])))
+                assert(key_results['cumulative_emissions_reduced'] == pytest.approx(float(df_expected.loc[3, 5])))

--- a/tools/expected_result_tester.py
+++ b/tools/expected_result_tester.py
@@ -1067,7 +1067,7 @@ def key_results_tester(solution_name, expected_filename, scenario_skip=None):
             obj = m.Scenario(scen=scenario_name)
             ac_file = zf.open(scenario_name + "/" + 'Advanced Controls')
             df_expected = pd.read_csv(ac_file, header=None, na_values=['#REF!', '#DIV/0!', '#VALUE!', '(N/A)'])
-            key_results = obj.key_results()
+            key_results = obj.get_key_results()
 
             if isinstance(obj, scenario.LandScenario):
                 assert(key_results['adoption_unit_increase'] == pytest.approx(float(df_expected.loc[3, 0])))


### PR DESCRIPTION
This PR includes several changes to key results that we discussed via email @denised 

Key results are now refactored into `RRSScenario` and `LandScenario`, `ht` is always used for adoption data and I changed from numpy `assert_almost_equal` to pytest.approx for testing.

Also `key_results()` is now called `get_key_results()`