### PR TITLE
Potential fix for multiple test failures related to HelperTables

### DIFF
--- a/solution/bikeinfrastructure/__init__.py
+++ b/solution/bikeinfrastructure/__init__.py
@@ -179,7 +179,8 @@ class Scenario(scenario.RRSScenario):
             use_first_pds_datapoint_main=False,
             copy_pds_to_ref=False, copy_ref_datapoint=False,
             pds_adoption_trend_per_region=pds_adoption_trend_per_region,
-            pds_adoption_is_single_source=pds_adoption_is_single_source)
+            pds_adoption_is_single_source=pds_adoption_is_single_source,
+            copy_pds_datapoint=False)
 
         self.ef = emissionsfactors.ElectricityGenOnGrid(ac=self.ac, grid_emissions_version=3)
 

--- a/solution/composting/__init__.py
+++ b/solution/composting/__init__.py
@@ -182,7 +182,8 @@ class Scenario(scenario.RRSScenario):
             use_first_pds_datapoint_main=False,
             copy_pds_to_ref=False,
             pds_adoption_trend_per_region=pds_adoption_trend_per_region,
-            pds_adoption_is_single_source=pds_adoption_is_single_source)
+            pds_adoption_is_single_source=pds_adoption_is_single_source,
+            copy_pds_datapoint=False)
 
         self.ef = emissionsfactors.ElectricityGenOnGrid(ac=self.ac)
 

--- a/solution/walkablecities/__init__.py
+++ b/solution/walkablecities/__init__.py
@@ -200,7 +200,8 @@ class Scenario(scenario.RRSScenario):
             use_first_pds_datapoint_main=False,
             copy_pds_to_ref=False, copy_ref_datapoint=False,
             pds_adoption_trend_per_region=pds_adoption_trend_per_region,
-            pds_adoption_is_single_source=pds_adoption_is_single_source)
+            pds_adoption_is_single_source=pds_adoption_is_single_source,
+            copy_pds_datapoint=False)
 
         self.ef = emissionsfactors.ElectricityGenOnGrid(ac=self.ac, grid_emissions_version=3)
 


### PR DESCRIPTION
This PR relates to #317 where we've been trying to find a fix for multiple, possibly related testing failures.

I found that for the composting solution, adding copy_pds_datapoint=False to the definition of `HelperTables` solves the testing failure.

I also believe that the same change should be bikeinfrastructure & buildingautomation
It fixes the current cause for testing failure but then another testing failure occurs.

I will check how this small change affects the other problematic solutions discussed in the issue and report as soon as I think this PR is ready for merge.