### PR TITLE
Fix extraction of solution description from Excel - column E not D.

### DIFF
--- a/tools/solution_xls_extract.py
+++ b/tools/solution_xls_extract.py
@@ -93,7 +93,7 @@ def get_rrs_scenarios(wb, solution_category):
             s['solution_category'] = solution_category
             s['vmas'] = 'VMAs'
 
-            s['description'] = xls(sr_tab, row + 1, co("D"))
+            s['description'] = xls(sr_tab, row + 1, co("E"))
             report_years = xls(sr_tab, row + 2, co("E"))  # E:2 from top of scenario
             (start, end) = report_years.split('-')
             s['report_start_year'] = int(start)


### PR DESCRIPTION
This bug resulted in the bogus extraction of description text consisting only of the word 'Description:' for solutions commercialglass, hcrecycling, hfc_replacement, methaneleak, recycledmetals, recycledplastics, residentialglass, and sustainableclothing. (Those solutions still need a fix in their submitted ac/*.json files).