### PR TITLE
Add creation_date to AdvancedControls python object, to correspond with its addition to the .json files.

### DIFF
--- a/model/advanced_controls.py
+++ b/model/advanced_controls.py
@@ -53,6 +53,9 @@ class AdvancedControls:
     # description: freeform text describing the construction or intention for this scenario.
     description: str = None
 
+    # Creation date of this scenario, in %Y-%m-%d %H:%M:%S format.
+    creation_date: str = None
+
     # js: JSON this AdvancedControls object was created from (if any)
     # jsfile: the filename containing the JSON (if any)
     js: str = None


### PR DESCRIPTION
Can't verify. I ran 'python -m pytest solution/commercialglass'
and it said
___ ERROR collecting solution/commercialglass/tests/test_commercialglass.py ____
solution/commercialglass/tests/test_commercialglass.py:6: in <module>
    from tools import expected_result_tester
tools/expected_result_tester.py:16: in <module>
    from model import scenario
model/scenario.py:15: in <module>
    from solution import factory
solution/factory.py:25: in <module>
    def load_scenario(solution, scenario=None) -> scenario.Scenario :
E   AttributeError: partially initialized module 'model.scenario' has no attribute 'Scenario' (most likely due to a circular import)

...and that happens on a clean branch too, so there's some other issue that needs fixing before we can confirm this PR is ok.