### PR TITLE
bug fix Scenario class

### DIFF
--- a/model/scenario.py
+++ b/model/scenario.py
@@ -97,14 +97,30 @@ class Scenario:
 
     # Control of adoption initialization is a combination of the contents of the ac parameters
     # and the settings of these fields by the subclass
+
     _ref_ca_sources = None  
     _pds_ca_sources = None 
-    _pds_ca_settings = { 'high_sd_mult' : 1.0, 'low_sd_mult' : 1.0 }
     _pds_ad_sources = None
+    _pds_ca_settings = { 'high_sd_mult' : 1.0, 'low_sd_mult' : 1.0 }
     _pds_ad_settings = { 'main_includes_regional' : False, 'groups_include_hundred_percent': True,
         'config_overrides' : None }
     _pds_sc_settings = { 'use_tam_2014': True }
+     # Note: to function properly, you have to *assign* to the the previous fields, not *modify* them.
+    # (if you modify them, they remain class fields, and the modification will affect all scenarios).
+    # The convenience functions that follow will helpfully do this for you.
     
+    def pds_ca_overrides(self, sd_high_mult=1.0, sd_low_mult=1.0):
+        """Set values to override the default ca settings"""
+        self._pds_ca_settings = { 'high_sd_mult': sd_high_mult, 'low_sd_mult': sd_low_mult}
+    def pds_ad_overrides(self, main_includes_regional=False, groups_include_hundred_percent=True, config_overrides=None):
+        """config_overrides: list( tuple(param, region, value) ), where region may be '*' to change all regions"""
+        self._pds_ad_settings = {
+            'main_includes_regional': main_includes_regional,
+            'groups_include_hundred_percent': groups_include_hundred_percent,
+            'config_overrides': config_overrides
+        }
+    def pds_sc_overrides(self, use_tam_2014: True):
+        self._pds_sc_settings = { 'use_tam_2014': use_tam_2014 }
 
     def initialize_adoption_bases(self):
         """Initialize the pds and ref adoption bases for this scenario to one of 

--- a/model/tam.py
+++ b/model/tam.py
@@ -39,6 +39,9 @@ def make_tam_config(tam_config_array=None, overrides=None) -> pd.DataFrame:
                 tamconfig.loc[param] = val
             else:
                 tamconfig.loc[param,region] = val
+                # World and PDS World always have the same value
+                if region == 'World':
+                    tamconfig.loc[param,'PDS World'] = val
     return tamconfig
 
 

--- a/solution/biogas/__init__.py
+++ b/solution/biogas/__init__.py
@@ -69,7 +69,7 @@ class Scenario(scenario.RRSScenario):
 
         # ADOPTION
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['groups_include_hundred_percent'] = False
+        self.pds_ad_overrides(groups_include_hundred_percent=False)
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/improvedcookstoves/__init__.py
+++ b/solution/improvedcookstoves/__init__.py
@@ -66,8 +66,7 @@ class Scenario(scenario.RRSScenario):
 
         # ADOPTION
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['config_overrides'] = [('low_sd_mult','World',0.25), ('high_sd_mult','World',0.8)]
-        self._pds_ad_settings['main_includes_regional'] = False
+        self.pds_ad_overrides(config_overrides=[('low_sd_mult','World',0.25), ('high_sd_mult','World',0.8)])
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/instreamhydro/__init__.py
+++ b/solution/instreamhydro/__init__.py
@@ -70,7 +70,6 @@ class Scenario(scenario.RRSScenario):
         self._ref_ca_sources = scenario.load_sources(THISDIR/'ca_ref_data'/'ca_ref_sources.json', 'filename')
         self._pds_ca_sources = scenario.load_sources(THISDIR/'ca_pds_data'/'ca_pds_sources.json', 'filename')
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['main_includes_regional'] = False
         self.initialize_adoption_bases()
         if self.ac.soln_ref_adoption_basis == 'Custom':
             ref_adoption_data_per_region = self.ref_ca.adoption_data_per_region()

--- a/solution/landfillmethane/__init__.py
+++ b/solution/landfillmethane/__init__.py
@@ -69,7 +69,6 @@ class Scenario(scenario.RRSScenario):
         # ADOPTION
         self._pds_ca_sources = scenario.load_sources(THISDIR/'ca_pds_data'/'ca_pds_sources.json', 'filename')
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['main_includes_regional'] = False
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/leds_commercial/__init__.py
+++ b/solution/leds_commercial/__init__.py
@@ -66,8 +66,7 @@ class Scenario(scenario.RRSScenario):
 
         # ADOPTION
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['config_overrides'] = [('growth','Asia (Sans Japan)','Low')]
-        self._pds_ad_settings['main_includes_regional'] = False
+        self.pds_ad_overrides(config_overrides=[('growth','Asia (Sans Japan)','Low')])
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/microwind/__init__.py
+++ b/solution/microwind/__init__.py
@@ -68,8 +68,7 @@ class Scenario(scenario.RRSScenario):
 
         # ADOPTION
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['groups_include_hundred_percent'] = False
-        self._pds_ad_settings['main_includes_regional'] = False
+        self.pds_ad_overrides(groups_include_hundred_percent=False)
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/nuclear/__init__.py
+++ b/solution/nuclear/__init__.py
@@ -71,7 +71,6 @@ class Scenario(scenario.RRSScenario):
         self._ref_ca_sources = scenario.load_sources(THISDIR/'ca_ref_data'/'ca_ref_sources.json', 'filename')
         self._pds_ca_sources = scenario.load_sources(THISDIR/'ca_pds_data'/'ca_pds_sources.json', 'filename')
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['main_includes_regional'] = False
         self.initialize_adoption_bases()
         if self.ac.soln_ref_adoption_basis == 'Custom':
             ref_adoption_data_per_region = self.ref_ca.adoption_data_per_region()

--- a/solution/offshorewind/__init__.py
+++ b/solution/offshorewind/__init__.py
@@ -68,8 +68,7 @@ class Scenario(scenario.RRSScenario):
 
         # ADOPTION
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['groups_include_hundred_percent'] = False
-        self._pds_ad_settings['main_includes_regional'] = False
+        self.pds_ad_overrides(groups_include_hundred_percent=False)
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/onshorewind/__init__.py
+++ b/solution/onshorewind/__init__.py
@@ -69,8 +69,7 @@ class Scenario(scenario.RRSScenario):
 
         # ADOPTION
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['groups_include_hundred_percent'] = False
-        self._pds_ad_settings['main_includes_regional'] = False
+        self.pds_ad_overrides(groups_include_hundred_percent=False)
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/recycledpaper/__init__.py
+++ b/solution/recycledpaper/__init__.py
@@ -68,7 +68,6 @@ class Scenario(scenario.RRSScenario):
         # ADOPTION
         self._pds_ca_sources = scenario.load_sources(THISDIR/'ca_pds_data'/'ca_pds_sources.json', 'filename')
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['main_includes_regional'] = False
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/solarhotwater/__init__.py
+++ b/solution/solarhotwater/__init__.py
@@ -67,7 +67,6 @@ class Scenario(scenario.RRSScenario):
         # ADOPTION
         self._pds_ca_sources = scenario.load_sources(THISDIR/'ca_pds_data'/'ca_pds_sources.json', 'filename')
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['main_includes_regional'] = False
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/solarpvroof/__init__.py
+++ b/solution/solarpvroof/__init__.py
@@ -68,8 +68,7 @@ class Scenario(scenario.RRSScenario):
 
         # ADOPTION
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['groups_include_hundred_percent'] = False
-        self._pds_ad_settings['main_includes_regional'] = False
+        self.pds_ad_overrides(groups_include_hundred_percent=False)
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/solarpvutil/__init__.py
+++ b/solution/solarpvutil/__init__.py
@@ -68,8 +68,7 @@ class Scenario(scenario.RRSScenario):
 
          # ADOPTION
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['groups_include_hundred_percent'] = False
-        self._pds_ad_settings['main_includes_regional'] = False
+        self.pds_ad_overrides(groups_include_hundred_percent=False)
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/solution/walkablecities/changelog
+++ b/solution/walkablecities/changelog
@@ -1,3 +1,4 @@
+Old notes no longer relevant; nothing interesting happened.
 Denton's Notes:
 Walkable Cities
 In the third scenario in ScenarioRecord, "PDS2-7p2050-2.4% Annual Density Increase (Book Ed.1)", Fuel Cost Conventional in E746 and 

--- a/solution/wastetoenergy/__init__.py
+++ b/solution/wastetoenergy/__init__.py
@@ -70,7 +70,6 @@ class Scenario(scenario.RRSScenario):
         # ADOPTION
         self._pds_ca_sources = scenario.load_sources(THISDIR/'ca_pds_data'/'ca_pds_sources.json', 'filename')
         self._pds_ad_sources = scenario.load_sources(THISDIR/'ad'/'ad_sources.json', '*')
-        self._pds_ad_settings['main_includes_regional'] = False
         self.initialize_adoption_bases()
         ref_adoption_data_per_region = None
 

--- a/tools/solution_xls_extract.py
+++ b/tools/solution_xls_extract.py
@@ -838,11 +838,14 @@ def write_ad(f, wb, outputdir):
         regional = convert_bool(xls(a, 'B30')) and convert_bool(xls(a, 'B31'))
         if regional or is_elecgen:
             f.write("        # other AD parameter overrides\n")
-        if regional:
-            f.write("        self._pds_ad_settings['main_includes_regional'] = True\n") 
-        if is_elecgen:
+        if regional and is_elecgen:
             f.write("        # groups_include_hundred_percent is a quirks parameter that should apply to energy solutions only\n")
-            f.write("        self._pds_ad_settings['groups_include_hundred_percent'] = False\n")
+            f.write("        self.pds_ad_overrides(main_includes_regional=True, groups_include_hundred_percent=False)\n")
+        elif regional:
+            f.write("        self.pds_ad_overrides(main_includes_regional=True)\n") 
+        elif is_elecgen:
+            f.write("        # groups_include_hundred_percent is a quirks parameter that should apply to energy solutions only\n")
+            f.write("        self.pds_ad_overrides(groups_include_hundred_percent=False)\n")
         f.write("        self._pds_ad_sources = scenario.load_sources(THISDIR/'ad/ad_sources.json', '*')\n")
 
         write_json(filename=Path(outputdir)/'ad/ad_sources.json', d=sources)


### PR DESCRIPTION
class Scenario has shared class variables that become instance variables when overridden --- but only if you override them.  If you modify them instead, you modify the class variable which then affects all other instances as well.  In this case, it meant that overridden adoption parameters became permanent, and affected subsequent instantiated scenarios.  Detected because walkablecities passed tests by itself, but failed when tested together with other solutions.  I'm amazed that there weren't more issues.

Also deleted a bunch of overrides that were just re-affirming the default value.